### PR TITLE
BUG: should skip launch page if already logged in

### DIFF
--- a/closet-tracker/app/(login)/login.tsx
+++ b/closet-tracker/app/(login)/login.tsx
@@ -1,5 +1,5 @@
 import { View, Text, TextInput, ActivityIndicator, Button, StyleSheet } from 'react-native';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { auth } from '@/FirebaseConfig';
@@ -11,6 +11,15 @@ export default function Login() {
     const [password, setPassword] = useState('');
     const [loading, setLoading] = useState(false);
     const [user, setUser] = useState<any>(null);
+        
+    useEffect (() => {
+        const unsubscribe = auth.onAuthStateChanged((user) => {
+            if (user) {
+                router.replace('../(tabs)/wardrobe');
+            }
+        });
+        return unsubscribe;
+    }, []);
 
     const router = useRouter();
 

--- a/closet-tracker/app/(login)/signup.tsx
+++ b/closet-tracker/app/(login)/signup.tsx
@@ -1,5 +1,5 @@
 import { View, Text, TextInput, ActivityIndicator, Button, StyleSheet } from 'react-native';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { auth } from '@/FirebaseConfig';
@@ -11,6 +11,15 @@ export default function Signup() {
     const [password, setPassword] = useState('');
     const [loading, setLoading] = useState(false);
     const [user, setUser] = useState<any>(null);
+    
+    useEffect (() => {
+        const unsubscribe = auth.onAuthStateChanged((user) => {
+            if (user) {
+                router.replace('../(tabs)/wardrobe');
+            }
+        });
+        return unsubscribe;
+    }, []);
 
     const router = useRouter();
 

--- a/closet-tracker/app/index.tsx
+++ b/closet-tracker/app/index.tsx
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, Button, TouchableOpacity, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
+import { auth } from '@/FirebaseConfig';
 
 export default function Index() {
   const router = useRouter();
+
+  useEffect (() => {
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      if (user) {
+        router.replace('./(tabs)/wardrobe');
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
user experienced that after reloading app, would go to launch page even if already logged in, so can click the continue as guest option

fixed so that whenever login is detected in launch, login, or signup page, would automatically redirect to tabs.


https://github.com/user-attachments/assets/b29a8b9f-64ba-41fe-baf7-d45b79165b42

closes #65 