### PR TITLE
Created empty laundry page

### DIFF
--- a/closet-tracker/app/(screens)/_layout.tsx
+++ b/closet-tracker/app/(screens)/_layout.tsx
@@ -5,6 +5,7 @@ export default function RootLayout() {
     <Stack>
         <Stack.Screen name="singleItem" options={{ headerShown: false }} />
         <Stack.Screen name="uploadClothingData" options={{ headerShown: false }} />
+        <Stack.Screen name="laundry" options={{ headerShown: false }} />
     </Stack>
   );
 }

--- a/closet-tracker/app/(screens)/laundry.tsx
+++ b/closet-tracker/app/(screens)/laundry.tsx
@@ -1,0 +1,30 @@
+import { StyleSheet, Text, Button } from 'react-native';
+import React from 'react';
+import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+
+export default function LaundryScreen() {
+    const router = useRouter();
+
+    return (
+      <SafeAreaProvider>
+          <SafeAreaView style={styles.container}>
+            <Text style={styles.title}>Laundry Bin</Text>
+            <Button title="Back to Wardrobe" onPress={() => router.replace(`../(tabs)/wardrobe`)} />
+          </SafeAreaView>
+      </SafeAreaProvider>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: '#fff',
+        paddingTop: 10,
+    },
+    title: {
+        fontSize: 32,
+        fontWeight: 'bold',
+        paddingHorizontal: 15,
+    },
+});

--- a/closet-tracker/app/(tabs)/wardrobe.tsx
+++ b/closet-tracker/app/(tabs)/wardrobe.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, FlatList, Text, TouchableOpacity, Platform, View, Image, RefreshControl, Pressable } from 'react-native';
+import { StyleSheet, FlatList, Text, TouchableOpacity, Platform, View, Image, RefreshControl, Pressable, useColorScheme } from 'react-native';
 import React, { useEffect, useState, useCallback } from 'react';
 import { SafeAreaView, SafeAreaProvider } from 'react-native-safe-area-context';
 import { getAuth, onAuthStateChanged } from "firebase/auth";
@@ -6,6 +6,7 @@ import { getFirestore, collection, onSnapshot, doc, deleteDoc } from "firebase/f
 import { useRouter } from 'expo-router';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { TextInput } from 'react-native-gesture-handler';
+import { Colors } from '@/constants/Colors';
 
 type ItemType = {
   id: string;
@@ -36,6 +37,7 @@ export default function WardrobeScreen() {
   const [refreshing, setRefreshing] = useState(true);
   const [user, setUser] = useState<any>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const colorScheme = useColorScheme();
 
   const auth = getAuth();
   const db = getFirestore();
@@ -212,6 +214,11 @@ export default function WardrobeScreen() {
             }
           />
         )}
+        <TouchableOpacity
+          style={styles.laundryButton}
+          onPress={() => router.replace(`../(screens)/laundry`)}>
+            <IconSymbol name={"archivebox.fill"} color={Colors[colorScheme ?? 'light'].tabIconSelected} />
+        </TouchableOpacity>
       </SafeAreaView>
     </SafeAreaProvider>
   );
@@ -311,4 +318,17 @@ const styles = StyleSheet.create({
     right:10,
     padding:10,
   },
+  laundryButton: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 80,
+    height: 80,
+    backgroundColor: '#fff',
+    borderRadius: 50,
+    position: 'absolute',
+    bottom: 100,
+    right: 50
+  }
 });

--- a/closet-tracker/components/ui/IconSymbol.tsx
+++ b/closet-tracker/components/ui/IconSymbol.tsx
@@ -17,6 +17,7 @@ const MAPPING = {
   "shippingbox.fill": "archive",
   "trash": "delete-outline",
   "xmark.app": "cancel",
+  "archivebox.fill": "inventory"
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],


### PR DESCRIPTION
Added an empty laundry page as well as a button on the wardrobe page which routes to the laundry page. The laundry page also links back to the wardrobe page. 

<img src="https://github.com/user-attachments/assets/db92a430-0f93-49e4-bf95-6f94ab306cfe" height="500">
<img src="https://github.com/user-attachments/assets/fb4c62e7-357d-49e2-8175-5d08982e41f3" height="500">


Next steps (implementation details may change):
- Laundry page will hold a flatlist of items in the user's laundry, similar to the wardrobe page
- Firebase will have a collection of items for the laundry
- User can move items from their wardrobe collection to laundry collection, and same vice versa
