### PR TITLE
Fixed upload page's dropdown and text input

### DIFF
--- a/closet-tracker/components/UploadClothingComponents.tsx
+++ b/closet-tracker/components/UploadClothingComponents.tsx
@@ -156,6 +156,9 @@ const clothingDataDropdowns = ({
           style={styles.dropdown}
           zIndex={2000}
           listMode={"SCROLLVIEW"}
+          searchable={true}
+          searchContainerStyle={{borderBottomWidth: 0}}
+          searchTextInputStyle={styles.input}
         />
       ),
     },
@@ -173,6 +176,9 @@ const clothingDataDropdowns = ({
           style={styles.dropdown}
           zIndex={1000}
           listMode={"SCROLLVIEW"}
+          searchable={true}
+          searchContainerStyle={{borderBottomWidth: 0}}
+          searchTextInputStyle={styles.input}
         />
       ),
     },


### PR DESCRIPTION
While uploading a clothing item, the user can now scroll through the whole list of color, size, and type options. For color and type dropdowns, the user can also search for their desired option. Additionally, when the user presses on the text input bars, the keyboard doesn't fully cover everything anymore, as you can now scroll to get the text input back into view.

Demo video of scrollable dropdowns: https://drive.google.com/file/d/19x48BxY40pFtJOynsE7ob_0nP-No-pc8/view?usp=drive_link
Demo picture of searchable dropdowns (only color and type, not size): https://drive.google.com/file/d/1CZJNUZfsMe6ARgPuphsGlNrskqCZBb9m/view?usp=drive_link

Closes #84 

Future items:
- With Gretchen's current PR (filtering items), filters should use the same list of items as the upload page component