### PR TITLE
fix stats going out of bounds

### DIFF
--- a/closet-tracker/app/(app)/(tabs)/user.tsx
+++ b/closet-tracker/app/(app)/(tabs)/user.tsx
@@ -424,18 +424,20 @@ const styles = StyleSheet.create({
   },
   statsContainer: {
     flexDirection: 'row',
-    gap: 10,
+    flexWrap: 'wrap',
     justifyContent: 'space-around',
     backgroundColor: beigeColors.softBrown,
     borderRadius: 8,
     padding: 15,
+    width: '100%',
   },
   statItem: {
     alignItems: 'center',
     justifyContent: 'center',
+    width: '30%',
   },
   statValue: {
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: 'bold',
     color: beigeColors.darkBeige,
   },


### PR DESCRIPTION
- fixed issue where "Number of Outfits" stat got pushed out of bounds on ios. see before and after

Before:
![IMG_1388](https://github.com/user-attachments/assets/776bd998-f721-4ef2-9e50-af9b39db8c4c)

After:
![IMG_1387](https://github.com/user-attachments/assets/50bdebcd-4488-40a1-9896-f120b3ee75a5)
