### PR TITLE
Fixed two bugs with edit button

### DIFF
--- a/closet-tracker/app/(app)/(screens)/editItem.tsx
+++ b/closet-tracker/app/(app)/(screens)/editItem.tsx
@@ -77,7 +77,8 @@ export default function EditItem () {
     color: string | null,
     clothingType: string | null,
     brand: string,
-    note: string
+    note: string,
+    wearCount: number | null
   ) => {
     if (!user) {
       alert("Please sign in before uploading your clothes.");
@@ -98,7 +99,7 @@ export default function EditItem () {
         clothingType: clothingType,
         brand: brand,
         note: note,
-        wearCount: 0,
+        wearCount: wearCount,
         dateUploaded: serverTimestamp()
       });
       

--- a/closet-tracker/app/(app)/(screens)/singleItem.tsx
+++ b/closet-tracker/app/(app)/(screens)/singleItem.tsx
@@ -62,8 +62,12 @@ export default function singleItem() {
   }, [collectionId, itemId, currentUser]);
 
   const handleEdit = () => {
-    if (!currentUser || collectionId !== "clothing") return;
-    router.push(`../(screens)/editItem?item_id=${itemId}&collections=${collectionId}`);
+    if (!currentUser) return;
+    if (collectionId === "outfit") {
+      router.push(`../(screens)/canvas?outfitId=${itemId}`);
+    } else { // wardrobe, laundry pages
+      router.push(`../(screens)/editItem?item_id=${itemId}&collections=${collectionId}`);
+    }
   };
   
   const handleMakePublic = async () => {
@@ -192,10 +196,9 @@ export default function singleItem() {
             <Pressable onPress={() => router.back()} style={styles.button}>
                 <Text style={styles.buttonText}>Back</Text>
             </Pressable> 
-            {(collectionId == "clothing") ? 
-              <Pressable onPress={() => handleEdit()} style={styles.button}>
-                <Text style={styles.buttonText}>Edit</Text>
-              </Pressable> : <></>}
+            <Pressable onPress={() => handleEdit()} style={styles.button}>
+              <Text style={styles.buttonText}>Edit</Text>
+            </Pressable>
             
           </View>
 

--- a/closet-tracker/app/(app)/(screens)/singleItem.tsx
+++ b/closet-tracker/app/(app)/(screens)/singleItem.tsx
@@ -61,20 +61,6 @@ export default function singleItem() {
     checkPublicStatus();
   }, [collectionId, itemId, currentUser]);
 
-  // const updateWearCount = async (newCount: number) => {
-  //   if (!itemId || newCount < 0) return;
-
-  //   if (!currentUser) return;
-
-  //   const itemRef = doc(db, "users", currentUser.uid, collectionId, itemId);
-
-  //   try {
-  //     await updateDoc(itemRef, { wearCount: newCount });
-  //     setWearCount(newCount);
-  //   } catch (error) {
-  //     console.error("Error updating wear count:", error);
-  //   }
-  // };
   const handleEdit = () => {
     if (!currentUser || collectionId !== "clothing") return;
     router.push(`../(screens)/editItem?item_id=${itemId}&collections=${collectionId}`);
@@ -206,9 +192,11 @@ export default function singleItem() {
             <Pressable onPress={() => router.back()} style={styles.button}>
                 <Text style={styles.buttonText}>Back</Text>
             </Pressable> 
-            <Pressable onPress={() => handleEdit()} style={styles.button}>
+            {(collectionId == "clothing") ? 
+              <Pressable onPress={() => handleEdit()} style={styles.button}>
                 <Text style={styles.buttonText}>Edit</Text>
-            </Pressable> 
+              </Pressable> : <></>}
+            
           </View>
 
         </View>

--- a/closet-tracker/components/UploadClothingComponents.tsx
+++ b/closet-tracker/components/UploadClothingComponents.tsx
@@ -12,7 +12,9 @@ export default function ClothingDataDropdowns ({
         size: string | null,
         color: string | null, 
         clothingType: string | null, 
-        brand: string, note: string
+        brand: string, 
+        note: string,
+        wearCount: number | null
     ) => Promise<void>; //for asynch?
     docSnapshot: DocumentSnapshot | null;
 
@@ -110,6 +112,7 @@ export default function ClothingDataDropdowns ({
   const [size, setSize] = useState(placeholders.size);
   const [clothingType, setClothingType] = useState(placeholders.clothingType);
   const [color, setColor] = useState(placeholders.color);
+  const [wearCount, setWearCount] = useState(placeholders.wearCount);
 
   useEffect(() => {
     setBrand(placeholders.brand);
@@ -118,6 +121,7 @@ export default function ClothingDataDropdowns ({
     setSize(placeholders.size);
     setClothingType(placeholders.clothingType);
     setColor(placeholders.color);
+    setWearCount(placeholders.wearCount);
   }, [placeholders]);
 
   // FlatList data
@@ -222,7 +226,7 @@ export default function ClothingDataDropdowns ({
     {
       key: 'submit',
       dropdown: (
-        <Button title="Submit" onPress={() => handleClothingSubmit(newName, size, color, clothingType, brand, note)} />
+        <Button title="Submit" onPress={() => handleClothingSubmit(newName, size, color, clothingType, brand, note, wearCount)} />
       ),
     },
   ];


### PR DESCRIPTION
Bug 1: Editing a clothing item's details causes wearCount to reset to 0
Bug 2: "Edit item" button shows for laundry items and outfit items, but doesn't do anything when clicked

Fix for bug 1: Now, editing clothing items doesn't reset the wear count. It stays as the number it was set at
~Fix for bug 2: removed "edit item" button from the two pages, only shows up for wardrobe items~
Fix for bug 2: "Edit" button from laundry page clothing item routes to the edit page for the clothing item. "Edit" button from outfit page item routes to the canvas to edit the outfit. Both changes reflect the behavior from multi-selecting items and pressing "edit" in the top bar.

Demo video: https://drive.google.com/file/d/1iZhYKSB5aoWoA9fK9F_bXH-R0hZKR63h/view?usp=sharing (outdated with original fix for bug 1)

Closes #155 