### PR TITLE
Adjusted background colors of items in wardrobe and laundry

### DIFF
--- a/closet-tracker/app/(app)/(screens)/laundry.tsx
+++ b/closet-tracker/app/(app)/(screens)/laundry.tsx
@@ -189,7 +189,19 @@ export default function LaundryScreen() {
   const renderItem = ({ item }: { item: any }) => {
     if (item.id === "\"STUB\"") return <View style={{ flex: 1, aspectRatio: 1, margin: 8 }} />;
     const isSelected = selectedIds.includes(item.id);
-    const backgroundColor = isSelected ? '#4160fb' : '#a5b4fd';
+    const getBackgroundColor = (wearCount: number, isSelected: boolean) => {
+      if (isSelected) return '#4160fb'; // Blue when selected
+
+      // Normalize wearCount to a range (e.g., 0 to 10 or 20)
+      const maxWearCount = 10;
+      const normalizedCount = Math.min(wearCount, maxWearCount) / maxWearCount;
+
+      // Interpolate lightness from 75% (light beige) to 30% (dark brown)
+      const lightness = 90 - normalizedCount * 45;
+
+      return `hsl(30, 50%, ${lightness}%)`; // HSL with a brownish hue
+    };
+    const backgroundColor = getBackgroundColor(item.wearCount, isSelected);
     const textColor = isSelected ? 'white' : 'black';
 
     return (

--- a/closet-tracker/app/(app)/(screens)/laundry.tsx
+++ b/closet-tracker/app/(app)/(screens)/laundry.tsx
@@ -196,7 +196,7 @@ export default function LaundryScreen() {
       const maxWearCount = 10;
       const normalizedCount = Math.min(wearCount, maxWearCount) / maxWearCount;
 
-      // Interpolate lightness from 75% (light beige) to 30% (dark brown)
+      // Interpolate lightness from 90% (light beige) to 30% (dark brown)
       const lightness = 90 - normalizedCount * 45;
 
       return `hsl(30, 50%, ${lightness}%)`; // HSL with a brownish hue

--- a/closet-tracker/app/(app)/(tabs)/wardrobe.tsx
+++ b/closet-tracker/app/(app)/(tabs)/wardrobe.tsx
@@ -189,7 +189,6 @@ export default function WardrobeScreen() {
   const renderItem = ({ item }: { item: any }) => {
     if (item.id === "\"STUB\"") return <View style={{ flex: 1, aspectRatio: 1, margin: 8 }} />;
     const isSelected = selectedIds.includes(item.id);
-    // const backgroundColor = isSelected ? '#4160fb' : '#a5b4fd';
     const getBackgroundColor = (wearCount: number, isSelected: boolean) => {
       if (isSelected) return '#4160fb'; // Blue when selected
 
@@ -198,7 +197,7 @@ export default function WardrobeScreen() {
       const normalizedCount = Math.min(wearCount, maxWearCount) / maxWearCount;
 
       // Interpolate lightness from 75% (light beige) to 30% (dark brown)
-      const lightness = 75 - normalizedCount * 45;
+      const lightness = 90 - normalizedCount * 45;
 
       return `hsl(30, 50%, ${lightness}%)`; // HSL with a brownish hue
     };

--- a/closet-tracker/app/(app)/(tabs)/wardrobe.tsx
+++ b/closet-tracker/app/(app)/(tabs)/wardrobe.tsx
@@ -196,7 +196,7 @@ export default function WardrobeScreen() {
       const maxWearCount = 10;
       const normalizedCount = Math.min(wearCount, maxWearCount) / maxWearCount;
 
-      // Interpolate lightness from 75% (light beige) to 30% (dark brown)
+      // Interpolate lightness from 90% (light beige) to 30% (dark brown)
       const lightness = 90 - normalizedCount * 45;
 
       return `hsl(30, 50%, ${lightness}%)`; // HSL with a brownish hue


### PR DESCRIPTION
Changes:
- Made clothing items in laundry also go from light beige to brown depending on the wear count, same as items in wardrobe.
- Edited the colors to start at a lighter beige (near white) so it doesn't look so dirty when unused and alarm the user. 

<img src="https://github.com/user-attachments/assets/86eaa6fc-15bd-470c-aaab-e3cf29bd38e2" height="500">
<img src="https://github.com/user-attachments/assets/1c26abff-f198-4abe-aeee-469536089360" height="500">

Future notes:
- Change background color of items in Outfits page. I wasn't sure if this should also be a changing color so I didn't change it, but I think it should not be the light blue color that it currently is