### PR TITLE
Fixed negative wear count bug

### DIFF
--- a/closet-tracker/components/SingleItemComponents.tsx
+++ b/closet-tracker/components/SingleItemComponents.tsx
@@ -57,8 +57,10 @@ export default function TimesWornComponent({
   };
 
   const handleDecrement = () => {
-    setWearCount(wearCount - 1);
-    updateWearCount(wearCount - 1);
+    if (wearCount - 1 >= 0) {
+      setWearCount(wearCount - 1);
+      updateWearCount(wearCount - 1);
+    }
   }
 
   // Max wear count (adjust this to fit your needs)


### PR DESCRIPTION
Previously, user could decrement a clothing item's wear count to be negative. Though it wouldn't save to Firebase, it was not intuitive to watch the count go down.

Now, the number doesn't go below 0 no matter how much the user presses the minus button.

Closes #158 